### PR TITLE
fix: https with basic auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.8.0</version>

--- a/src/main/java/com/lindar/wellrested/WellRestedRequest.java
+++ b/src/main/java/com/lindar/wellrested/WellRestedRequest.java
@@ -325,7 +325,7 @@ public class WellRestedRequest {
                     executor.clearCookies().clearAuth();
                 }
 
-                String host = uri.getPort() > 0 ? uri.getHost() + ":" + uri.getPort() : uri.getHost();
+                HttpHost host = new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
                 executor.auth(host, credentials);
                 executor.authPreemptive(host);
             }

--- a/src/test/java/com/lindar/wellrested/HttpsTest.java
+++ b/src/test/java/com/lindar/wellrested/HttpsTest.java
@@ -1,0 +1,26 @@
+package com.lindar.wellrested;
+
+import com.lindar.wellrested.vo.WellRestedResponse;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HttpsTest {
+    private final WellRestedRequestBuilder builder = new WellRestedRequestBuilder();
+
+    @ParameterizedTest
+    @CsvSource({
+        "correct-password, 200",
+        "incorrect-password, 401"
+    })
+    public void httpsWithCredentials(String password, int expectedStatusCode) {
+        builder.url("https://httpbin.org/basic-auth/username/correct-password");
+        builder.credentials(new UsernamePasswordCredentials("username", password.toCharArray()));
+
+        WellRestedResponse response = builder.build().get().submit();
+
+        assertEquals(expectedStatusCode, response.getStatusCode());
+    }
+}


### PR DESCRIPTION
**Notes:**
- this fixes https requests that require basic authentication
- I added a test that calls an external https endpoint with basic auth: `https://httpbin.org/basic-auth/username/password`, we might need to update or remove it in future