### PR TITLE
chore: removed slf4j-log4j12 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,13 +82,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>2.0.3</version>
+            <version>1.7.36</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Notes:**
- removing redundant dependency that sometimes causes unexpected problems with logging
![image](https://github.com/lindar-open/well-rested-client/assets/11297673/100e1f68-c356-48b4-920e-cf756ff2a44c)

- additionally, I downgraded `slf4j-api` to `1.7.36` as this app doesn't use any of `2.x` features anyway and we don't use `2.x` in Spring Boot 2 apps