### PR TITLE
chore: updated gson-javatime-serializers to support Duration class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.fatboyindustrial.gson-javatime-serialisers</groupId>
             <artifactId>gson-javatime-serialisers</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3-DURATION-SUPPORT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Notes:
- see [this commit](https://github.com/lindar-open/gson-javatime-serialisers/commit/5f736e083b6a2e2c4ba250c5393c23e7a8433f56) for more details